### PR TITLE
Fix format for Date type input parameters

### DIFF
--- a/certified-connectors/Impexium/apiDefinition.swagger.json
+++ b/certified-connectors/Impexium/apiDefinition.swagger.json
@@ -137,6 +137,7 @@
                 },
                 "activityDate": {
                   "type": "string",
+                  "format": "date",
                   "description": "Activity Date.",
                   "title": "Activity Date"
                 }
@@ -278,12 +279,14 @@
                 },
                 "startDate": {
                   "type": "string",
+                  "format": "date",
                   "description": "Start Date.",
                   "title": "Start Date",
                   "x-ms-visibility": "advanced"
                 },
                 "endDate": {
                   "type": "string",
+                  "format": "date",
                   "description": "End Date.",
                   "title": "End Date",
                   "x-ms-visibility": "advanced"
@@ -3525,7 +3528,7 @@
             "schema": {}
           }
         },
-        "summary": "When purchase is canceled",
+        "summary": "When a purchase is canceled",
         "description": "Triggers when a purchase is canceled. Supported Product Types: Course, Event (Sessions are included), Exam, Fund, Membership, Merchandise, Publication.",
         "operationId": "When-purchase-cancelled",
         "x-ms-trigger": "single",
@@ -6725,11 +6728,13 @@
         },
         "startDate": {
           "type": "string",
+          "format": "date",
           "title": "Start Date",
           "description": "Start Date."
         },
         "endDate": {
           "type": "string",
+          "format": "date",
           "title": "End Date",
           "description": "End Date.",
           "x-ms-visibility": "internal"
@@ -6791,11 +6796,13 @@
         },
         "startDate": {
           "type": "string",
+          "format": "date",
           "title": "Start Date",
           "description": "Start Date."
         },
         "endDate": {
           "type": "string",
+          "format": "date",
           "title": "End Date",
           "description": "End Date.",
           "x-ms-visibility": "internal"
@@ -6854,6 +6861,7 @@
         },
         "dateEarned": {
           "type": "string",
+          "format": "date",
           "title": "Earned Date",
           "description": "Earned Date."
         },
@@ -6900,7 +6908,7 @@
           "x-ms-visibility": "advanced"
         },
         "followUpDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Follow Up Date",
           "description": "Follow Up Date.",
@@ -6941,13 +6949,13 @@
           "description": "Nominated By Record Number."
         },
         "nominationDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Nomination Date",
           "description": "Nomination Date."
         },
         "awardedDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Awarded Date",
           "description": "Awarded Date.",
@@ -6987,13 +6995,13 @@
           "description": "Nominated By Record Number."
         },
         "nominationDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Nomination Date",
           "description": "Nomination Date."
         },
         "awardedDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Awarded Date",
           "description": "Awarded Date.",
@@ -7017,7 +7025,7 @@
       "type": "object",
       "properties": {
         "awardedDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Awarded Date",
           "description": "Awarded Date."
@@ -7828,7 +7836,7 @@
       "type": "object",
       "properties": {
         "awardedDate": {
-          "format": "date-time",
+          "format": "date",
           "type": "string",
           "title": "Awarded Date",
           "description": "Awarded Date."


### PR DESCRIPTION
Fix format for Date type input parameters


---
When submitting a connector, please check the following conditions for your PR to ensure a smooth certification process.

- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


